### PR TITLE
[REDSTOCK-22] [백엔드] 증권사 리포트 > 리포트 목록 조회 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,12 @@
 .gradle
 .idea
+*.class
+*~
+.DS_Store
+.springBeans
+*.iml
+target
 build
-common/build
-item-api/build
-member-api/build
+common/src/main/generated
+out
+classes

--- a/common/src/main/kotlin/com/stock/api/service/item/ReportService.kt
+++ b/common/src/main/kotlin/com/stock/api/service/item/ReportService.kt
@@ -7,5 +7,5 @@ import org.springframework.data.domain.Pageable
 interface ReportService {
 
     fun getReports(pageable: Pageable): Page<Report>
-    fun getReport(id: Long): Report?
+    fun getReport(id: Long): Report
 }

--- a/item-api/src/main/kotlin/com/stock/api/controller/report/ReportController.kt
+++ b/item-api/src/main/kotlin/com/stock/api/controller/report/ReportController.kt
@@ -8,6 +8,8 @@ import io.swagger.annotations.Api
 import io.swagger.annotations.ApiOperation
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
+import org.springframework.data.web.PageableDefault
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
@@ -23,18 +25,20 @@ class ReportController(val service: ReportService) {
         const val BASE_URI: String = "/api/v1/reports"
     }
 
-    @ApiOperation("증권사 레포트 목록 조회")
+    @ApiOperation("증권사 리포트 목록 조회")
     @GetMapping
-    fun getReport(pageable: Pageable): Mono<Page<ReportResponse>> {
+    fun getReports(
+        @PageableDefault(sort = ["createdDate"], direction = Sort.Direction.DESC) pageable: Pageable
+    ): Mono<Page<ReportResponse>> {
         val items = service.getReports(pageable)
         return Mono.just(items.map(Report::toReportResponse))
     }
 
-    @ApiOperation("증권사 레포트 조회")
+    @ApiOperation("증권사 리포트 조회")
     @GetMapping("/{id}")
-    fun getReport(@PathVariable id: Long): Mono<ReportResponse>? {
+    fun getRecommendedItem(@PathVariable id: Long): Mono<ReportResponse>? {
         val item = service.getReport(id)
-        return Mono.just(item!!.toReportResponse())
+        return Mono.just(item.toReportResponse())
     }
 
 }


### PR DESCRIPTION
[백엔드] 증권사 리포트 > 리포트 목록 조회 API 구현
https://engineer-developer.atlassian.net/browse/REDSTOCK-22

- adminConfig = ON 인것만 조회 되도록 : 예외처리 추가 
- 페이징 형태로 구현 : size = 20
